### PR TITLE
Add pylintrc file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,138 @@
+[MAIN]
+# Add <file or directory> to the black list. It should be a base name, not a
+# path. You may set this option multiple times.
+ignore=.git,tests
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=pylint.extensions.no_self_use
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+[MESSAGES CONTROL]
+# NOTE(gus): This is a long list.  A number of these are important and
+# should be re-enabled once the offending code is fixed (or marked
+# with a local disable)
+disable=
+# "F" Fatal errors that prevent further processing
+ import-error,
+# "I" Informational noise
+ c-extension-no-member,
+ locally-disabled,
+# "E" Error for important programming issues (likely bugs)
+ access-member-before-definition,
+ no-member,
+ no-method-argument,
+ no-self-argument,
+ not-an-iterable,
+# "W" Warnings for stylistic problems or minor programming issues
+ abstract-method,
+ arguments-differ,
+ attribute-defined-outside-init,
+ broad-except,
+ expression-not-assigned,
+ fixme,
+ global-statement,
+ non-parent-init-called,
+ not-callable,
+ protected-access,
+ redefined-builtin,
+ redefined-outer-name,
+ signature-differs,
+ super-init-not-called,
+ unpacking-non-sequence,
+ unused-argument,
+ unused-import,
+ unused-variable,
+ useless-super-delegation,
+ unnecessary-pass,
+ raise-missing-from,
+ arguments-renamed,
+ broad-exception-raised,
+ unspecified-encoding,
+ redundant-u-string-prefix,
+ unused-private-member,
+# "C" Coding convention violations
+ consider-iterating-dictionary,
+ consider-using-enumerate,
+ invalid-name,
+ len-as-condition,
+ missing-docstring,
+ singleton-comparison,
+ superfluous-parens,
+ ungrouped-imports,
+ wrong-import-order,
+ consider-using-f-string,
+ consider-using-dict-items,
+# "R" Refactor recommendations
+ consider-merging-isinstance,
+ consider-using-ternary,
+ duplicate-code,
+ inconsistent-return-statements,
+ no-else-return,
+ no-self-use,
+ redefined-argument-from-local,
+ simplifiable-if-statement,
+ too-few-public-methods,
+ too-many-ancestors,
+ too-many-arguments,
+ too-many-branches,
+ too-many-instance-attributes,
+ too-many-lines,
+ too-many-locals,
+ too-many-nested-blocks,
+ too-many-public-methods,
+ too-many-return-statements,
+ too-many-statements,
+ consider-using-set-comprehension,
+ useless-object-inheritance,
+ super-with-arguments,
+ use-dict-literal
+
+[BASIC]
+# Variable names can be 1 to 31 characters long, with lowercase and underscores
+variable-rgx=[a-z_][a-z0-9_]{0,30}$
+
+# Argument names can be 2 to 31 characters long, with lowercase and underscores
+argument-rgx=[a-z_][a-z0-9_]{1,30}$
+
+# Method names should be at least 3 characters long
+# and be lowercased with underscores
+method-rgx=([a-z_][a-z0-9_]{2,}|setUp|tearDown)$
+
+# Don't require docstrings on tests.
+no-docstring-rgx=((__.*__)|([tT]est.*)|setUp|tearDown)$
+
+[FORMAT]
+# Maximum number of characters on a single line.
+max-line-length=79
+
+[VARIABLES]
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+# _ is used by our localization
+additional-builtins=_
+
+[CLASSES]
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+[IMPORTS]
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=
+# should use oslo_serialization.jsonutils
+ json,
+ six
+
+[TYPECHECK]
+# List of module names for which member attributes should not be checked
+ignored-modules=_MovedItems
+
+[REPORTS]
+# Tells whether to display a full report or only the messages
+reports=no

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,4 @@ deps =
   {[testenv]deps}
   pylint
 commands =
-  pylint --rcfile=.pylintrc --output-format=colorized {posargs:neutron}
+  pylint --rcfile=.pylintrc --output-format=colorized {posargs:sarcharts}


### PR DESCRIPTION
tox has an environment for pylint but it was missing a configuration
file. This PR adds a standard one.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>