### PR TITLE
Disable pylint for comment lines

### DIFF
--- a/sarcharts/__init__.py
+++ b/sarcharts/__init__.py
@@ -64,6 +64,7 @@ class SarCharts:
                         os.path.realpath(__file__)) + "/html",
                         self.C.outputpath + "/html")
 
+    # pylint: disable=line-too-long
     def show_help(self, errmsg=""):
         print("Usage: sarcharts.py"
               + " [Options] [sarfilespath] [sarfilespath] [sarfilespath]..."


### PR DESCRIPTION
This PR disables the pylint long line checks for some comments that
would look rather odd formatted that way.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>